### PR TITLE
Remove "first week of the month" guidance on patch days

### DIFF
--- a/process/pcf-security.html.md.erb
+++ b/process/pcf-security.html.md.erb
@@ -53,7 +53,7 @@ Low vulnerabilities are all other issues that have a security impact. These incl
 
 ##<a id='release-policy'></a>Release Policy ##
 
-PCF schedules regular releases of software in the PCF Suite to address Low / Medium severity vulnerability exploits. These patch releases take place during the first week each month. When High severity vulnerability exploits are identified, PCF releases fixes to software in the PCF Suite on-demand, with as fast a turnaround as possible.
+PCF schedules regular monthly releases of software in the PCF Suite to address Low / Medium severity vulnerability exploits. When High severity vulnerability exploits are identified, PCF releases fixes to software in the PCF Suite on-demand, with as fast a turnaround as possible.
 
 ##<a id='alerts'></a>Alerts/Actions Archive
 


### PR DESCRIPTION
This really isn't true, so we should be less specific.

@absoludicrous @ajackson 