### PR TITLE
Correct port range for ssh_proxy to app communication

### DIFF
--- a/networking/diego-network-paths.html.md.erb
+++ b/networking/diego-network-paths.html.md.erb
@@ -82,6 +82,14 @@ The following table lists network communication paths that are internal for Dieg
   <td>Mutual TLS</td>
 </tr>
 <tr>
+  <td>diego_brain (SSH Proxy)</td>
+  <td>diego_cell (App instances)</td>
+  <td>Varies<sup>&#8225;</sup></td>
+  <td>TCP</td>
+  <td>SSH</td>
+  <td>SSH</td>
+</tr>
+<tr>
   <td>diego_brain (TPS Watcher)</td>
   <td>diego_database (Locket)</td>
   <td>8891</td>
@@ -178,14 +186,6 @@ The following table lists network communication paths that are outbound from Die
 </tr>
 <tr>
   <td>diego_brain (SSH Proxy)</td>
-  <td>App instances</td>
-  <td>2222</td>
-  <td>TCP</td>
-  <td>SSH</td>
-  <td>SSH</td>
-</tr>
-<tr>
-  <td>diego_brain (SSH Proxy)</td>
   <td>cloud_controller</td>
   <td>9022</td>
   <td>TCP</td>
@@ -255,6 +255,8 @@ The following table lists network communication paths that are outbound from Die
 <sup>&#42;&#42;</sup>MySQL authentication uses the MySQL native password method.
 
 <sup>&#8224;</sup>Applies only to deployments where internal MySQL is selected as the database.
+
+<sup>&#8225;</sup>These are the host-side ports that map to port 2222 in app instance containers and are typically within the range 61001 to 65534.
 
 ## <a id="consul"></a>Consul Communications
 


### PR DESCRIPTION
The Diego SSH proxy connects to a subset of ports on the Diego cells, namely those that forward traffic to port 2222 inside of app instance containers.

This correction also applies to the documentation for previous releases. From GitHub, this documentation first appears in 1.10.