### PR TITLE
Update api-cert-rotation.html.md.erb

### DIFF
--- a/pcf-infrastructure/api-cert-rotation.html.md.erb
+++ b/pcf-infrastructure/api-cert-rotation.html.md.erb
@@ -49,7 +49,7 @@ Perform the steps in the [Using Ops Manager API](../../customizing/ops-man-api.h
 
 To return the Ops Manager root CA certificate as a file, use `curl` to make the following API call:
 <pre>
-$ curl "https<span>:</span>//OPS-MAN-FQDN/api/v0/download\_root\_ca\_cert \
+$ curl "https<span>:</span>//OPS-MAN-FQDN/download\_root\_ca\_cert \
       -X GET \
       -H "Authorization: Bearer YOUR-UAA-ACCESS-TOKEN"
 </pre>


### PR DESCRIPTION
According to https://github.com/pivotal-cf/installation/blob/master/web/config/routes.rb#L45, the endpoint to download the cert is https://OPS-MAN-FQDN/download_root_ca_cert and not https://OPS-MAN-FQDN/api/v0/download_root_ca_cert