### PR TITLE
Add step to recreate all VMs on deploy of new CA

### DIFF
--- a/pcf-infrastructure/api-cert-rotation.html.md.erb
+++ b/pcf-infrastructure/api-cert-rotation.html.md.erb
@@ -189,6 +189,7 @@ To provide your own CA, see [Adding a Custom Certificate Authority](./custom-ca-
   Identify your newly added CA, which has `active` set to `false`. Record its GUID.
 
 1. Navigate to `https://OPS-MAN-FQDN` in a browser and log in to Ops Manager.
+1. Navigate to the BOSH Director tile, and open the Director Config section. Check the box that says `Recreate All VMs`. This will ensure that the newly generated CA propagates to all deployed VMS, and will prevent downtime during certificate regeneration. 
 1. Click **Apply Changes**. When the deploy finishes, continue to the next section.
 
 #### <a id='activate-new-ca'></a> Step 2: Activate the New CA
@@ -224,7 +225,9 @@ To provide your own CA, see [Adding a Custom Certificate Authority](./custom-ca-
 The API returns a successful response:
 <pre class="terminal">HTTP/1.1 200 OK</pre>
 
-1. Navigate to Ops Manager and click **Apply Changes**. When the deploy finishes, continue to the next section.
+1. In the browser, navigate to the BOSH Director tile, and open the Director Config section. 
+1. Check the box that says `Recreate All VMs`. This will help prevent downtime during certificate regeneration.
+1. Click **Apply Changes**. When the deploy finishes, continue to the next section.
 
 #### <a id='delete'></a> Step 4: Delete the Old CA
 


### PR DESCRIPTION
This PR adds a step to recreate all VMs when deploying a new CA and when activating that new CA.
- This is necessary in order to force BOSH to propagate your new CA onto all VMs via the IaaS metadata. 
- Skipping this step would result in downtime when regenerating certificates because some VMs would not trust the new CA while others would have certificates signed by that new CA.
- This should also be applied to all versions of OpsManager (PRs will be created).