### PR TITLE
Advise operators to upgrade past critical OM bug when rotating certs

### DIFF
--- a/pcf-infrastructure/api-cert-rotation.html.md.erb
+++ b/pcf-infrastructure/api-cert-rotation.html.md.erb
@@ -88,6 +88,8 @@ These steps will vary depending on which SAML provider you are using.
 
 ## <a id='rotate-non-config'></a> Rotate Non-Configurable Certificates
 
+<p class="note warning"><strong>WARNING:</strong> Due to a high impact bug in Ops Manager, you need to be running <strong>Ops Manager version 2.1.6 or higher</strong>. Make sure to upgrade to at least that patch version before running any of the following certificate rotation procedures.</p>
+
 Non-configurable certificates are certificates that are given to you by the company whose product you are using, as opposed to certificates you generate yourself.
 
 To rotate all your certificates, including creating and applying a new root certificate, follow the procedure in [Regenerate and Rotate CA Certificates](#rotate-ca).


### PR DESCRIPTION
Several customers have hit this issue and it's very difficult to get out of.  By simply reminding them they have to be on patch X or higher during the rotation process, we hope they catch that bug fix before it's too late.

Signed-off-by: David Stevenson <dstevenson@pivotal.io>