### PR TITLE
Include advice to recreate all service instances

### DIFF
--- a/pcf-infrastructure/api-cert-rotation.html.md.erb
+++ b/pcf-infrastructure/api-cert-rotation.html.md.erb
@@ -245,6 +245,14 @@ To prevent system downtime, this procedure includes two BOSH redeploys. When you
 
 1. Select **Recreate All VMs**. This propagates the new CA to all VMs to prevent downtime.
 
+1. Go back to the Installation Dashboard and, for each service tile you have installed:
+
+    1. Click on the tile
+
+    1. Click on the **Errands** tab
+
+    1. Enable the **Recreate All Service Instances** errand if provided.
+
 1. Click **Review Pending Changes**, then **Apply Changes**. When the deploy finishes, continue to the next section.
 
 #### <a id='activate-new-ca'></a> Step 2: Activate the New CA


### PR DESCRIPTION
As OpsManager doesn't know about ODB controlled service instance VMs, operators need to enable the `recreate-all-service-instances` errands for their service tiles during cert rotations. 

Note that not all service tiles will include this errand (only the on-demand tiles, and only after they have consumed the latest release of ODB). 

Co-authored-by: Derik Evangelista <devangelista@pivotal.io>