### PR TITLE
Fix broken links

### DIFF
--- a/identity/index.html.md.erb
+++ b/identity/index.html.md.erb
@@ -9,8 +9,8 @@ This section provides links to different aspects of identity management, includi
 
 The following topics provide general information about credential and identity management in PCF.
 
-* <a id="/pivotalcf/customizing/user-types.html">Understanding Pivotal Cloud Foundry User Types</a>
-* <a id="/pivotalcf/customizing/credentials.html">Retrieving Credentials from Your Deployment</a>
+* <a href="/pivotalcf/customizing/user-types.html">Understanding Pivotal Cloud Foundry User Types</a>
+* <a href="/pivotalcf/customizing/credentials.html">Retrieving Credentials from Your Deployment</a>
 
 ## <a id="credhub"></a> CredHub Documentation
 


### PR DESCRIPTION
Links were broken as they were using `id` when they should have been using `href`.