### PR TITLE
Update port and protocol for router -> cloud_controller traffic

### DIFF
--- a/networking/cc-network-paths.html.md.erb
+++ b/networking/cc-network-paths.html.md.erb
@@ -77,9 +77,9 @@ The following table lists network communication paths that are inbound to the Cl
 <tr>
   <td>router</td>
   <td>cloud_controller</td>
-  <td>9022</td>
+  <td>9024</td>
   <td>TCP</td>
-  <td>HTTP</td>
+  <td>HTTPS</td>
   <td>OAuth 2.0</td>
 </tr>
 </table>


### PR DESCRIPTION
The gorouters forward API traffic to the Cloud Controller APIs over TLS
beginning in PAS 2.3.

See the following release notes for more information:
https://docs.pivotal.io/pivotalcf/2-3/pcf-release-notes/runtime-rn.html#encyrpt-traffic

[#166615352](https://www.pivotaltracker.com/story/show/166615352)

This should be backported to the docs for PAS 2.3+. Thank you! 🙏 