### PR TITLE
Update port and protocol for ssh_proxy -> cloud_controller traffic

### DIFF
--- a/networking/cc-network-paths.html.md.erb
+++ b/networking/cc-network-paths.html.md.erb
@@ -37,9 +37,9 @@ The following table lists network communication paths that are inbound to the Cl
 <tr>
   <td>diego_brain (SSH Proxy)</td>
   <td>cloud_controller</td>
-  <td>9022</td>
+  <td>9024</td>
   <td>TCP</td>
-  <td>HTTP</td>
+  <td>HTTPS</td>
   <td>OAuth 2.0</td>
 </tr>
 <tr>


### PR DESCRIPTION
In PAS 2.5+ Diego's ssh_proxy now talks to Cloud Controller over TLS

This change was done in the following Diego story:
https://www.pivotaltracker.com/story/show/159803355

[#166615352](https://www.pivotaltracker.com/story/show/166615352)

This is similar to https://github.com/pivotal-cf/docs-pcf-security/pull/52, I submitted it as a separate PR because this commit should only be backported to the docs for PAS 2.5+.