### PR TITLE
Remove redundant step.

### DIFF
--- a/pcf-infrastructure/api-cert-rotation.html.md.erb
+++ b/pcf-infrastructure/api-cert-rotation.html.md.erb
@@ -104,21 +104,6 @@ To check the expiration dates of leaf certificates and identify the types of lea
       * `location` is either `ops_manager` or `credhub`
   * **Configurable Certificates**: Configurable leaf certificates have the following property value: `configurable` is `true`
 
-1. For any certificates expiring soon, use the following rules to identify their types:
-      * **Non-Rotatable Certificates**: Non-Rotatable certificates have the following property value:
-          * `variable_path` is `/opsmgr/bosh_dns/tls_ca`
-      * **Non-Configurable Certificates**: Non-Configurable leaf certificates have the following property values:
-          * `variable_path` is not `/opsmgr/bosh_dns/tls_ca`
-          * `configurable` is `false`
-          * `location` is either `ops_manager` or `credhub`
-          * `is_ca` is `false`
-      * **Configurable Certificates**: Configurable leaf certificates have the following property values:
-          * `configurable` is `true`
-          * `is_ca` is `false`
-      * **Ops Manager Root CA and matching BOSH NATS CA**: CAs have the following property values:
-          * `is_ca` is `true`
-          * `location` is `ops_manager`
-
 1. Continue to [Rotate Certificates](#rotate) with your list of certificate types that expire soon.
 
 ### <a id='rotate'></a> Rotate Certificates


### PR DESCRIPTION
Remove redundant step based on slack discussion: https://pivotal.slack.com/archives/C0554UNSS/p1576167141019400?thread_ts=1576033314.481000&cid=C0554UNSS

The removed step only applies to OpsMan 2.7+ which contains https://github.com/pivotal-cf/ops-manager/commit/3d30e3a9a17cbed8249bebde15a4515cb6115d79.

Thanks,
wchen@pivotal.io