### PR TITLE
file-server accepts HTTPS traffic from cells starting from 2.8

### DIFF
--- a/networking/diego-network-paths.html.md.erb
+++ b/networking/diego-network-paths.html.md.erb
@@ -116,18 +116,10 @@ The following table lists network communication paths that are internal for Dieg
 <tr>
   <td>diego_cell (Rep)</td>
   <td>diego_brain (File Server)<sup>&#8258;</sup></td>
-  <td>8080</td>
-  <td>TCP</td>
-  <td>HTTP</td>
-  <td>None</td>
-</tr>
-<tr>
-  <td>diego_cell (Rep) in Isolation Segment, different subnet</td>
-  <td>diego_brain (File Server)</td>
   <td>8447</td>
   <td>TCP</td>
   <td>HTTPS</td>
-  <td>Mutual TLS</td>
+  <td>TLS</td>
 </tr>
 <tr>
   <td>diego_cell (Rep)</td>


### PR DESCRIPTION
This fix should be backported to 2.8 branch since that's the default behavior.


[#171033491](https://www.pivotaltracker.com/story/show/171033491)