### PR TITLE
Updates docs for 2.9 to reflect renamed checkbox

### DIFF
--- a/pcf-infrastructure/api-cert-rotation.html.md.erb
+++ b/pcf-infrastructure/api-cert-rotation.html.md.erb
@@ -254,7 +254,7 @@ To add new CAs:
 
 1. Select the **Director Config** pane.
 
-1. Select **Recreate All VMs**. This propagates the new CA to all VMs to prevent downtime.
+1. Select **Recreate VMs deployed by the BOSH Director**. This propagates the new CA to all VMs deployed by the BOSH Director to prevent downtime.
 
 1. Go back to the Installation Dashboard. For each service tile you have installed:
 
@@ -339,7 +339,7 @@ The API returns a successful response:
 
 1. Select the **Director Config** pane.
 
-1. Select **Recreate All VMs**. This propagates the new CAs to all VMs to prevent downtime.
+1. Select **Recreate VMs deployed by the BOSH Director**. This propagates the new CAs to all VMs deployed by the BOSH Director to prevent downtime.
 
 1. Go back to the Installation Dashboard. For each service tile you have installed:
 


### PR DESCRIPTION
"Recreate all VMs" is being renamed to "Recreate VMs deployed by the
BOSH Director". This updates these docs.

[#170244457] The recreate-all-vms checkbox is incorrectly named