### PR TITLE
Warning when certificates have already expired

### DIFF
--- a/pcf-infrastructure/api-cert-rotation.html.md.erb
+++ b/pcf-infrastructure/api-cert-rotation.html.md.erb
@@ -108,6 +108,8 @@ This section includes procedures for rotating CAs and leaf certificates. There a
 
 You can determine which rotation procedure to follow based on the types of certificates in your foundation that must be rotated. For more information about identifying the types of certificates in your foundation that expire soon, see [Check Expiration Dates and Certificate Types](#checks).
 
+<p class='note warning'><strong>Warning:</strong> The rotation procedures described in this topic do not work if the certificates have already expired. If the certificates have expired, contact <a href="https://support.pivotal.io/">Pivotal Support</a> for guidance.</p>
+
 To rotate certificates, follow one of these procedures:
 
 * To rotate non-rotatable certificates, contact [Pivotal Support](http://support.pivotal.io).


### PR DESCRIPTION
Added another warning in the main "Rotate Certificates" section to contact support when certificates have already expired.