### PR TITLE
Warning when certificates have already expired

### DIFF
--- a/pcf-infrastructure/api-cert-rotation.html.md.erb
+++ b/pcf-infrastructure/api-cert-rotation.html.md.erb
@@ -94,6 +94,8 @@ This section explains how to rotate certificates in <%= vars.platform_name %>, i
 
 You can determine which rotation procedure to follow based on the types of certificates in your foundation that must be rotated.
 
+<p class='note warning'><strong>Warning:</strong> The rotation procedures described in this topic do not work if the certificates have already expired. If the certificates have expired, contact <a href="https://support.pivotal.io/">Pivotal Support</a> for guidance.</p>
+
 To rotate certificates, follow one of these procedures:
 
 * To rotate non-rotatable certificates, contact [Pivotal Support](http://support.pivotal.io).


### PR DESCRIPTION
Added another warning in the main "Rotate Certificates" section to contact support when certificates have already expired.