### PR TITLE
Warning when certificates have already expired

### DIFF
--- a/pcf-infrastructure/api-cert-rotation.html.md.erb
+++ b/pcf-infrastructure/api-cert-rotation.html.md.erb
@@ -104,6 +104,8 @@ This section explains how to rotate certificates in <%= vars.platform_name %>, i
 
 You can determine which rotation procedure to follow based on the types of certificates in your foundation that must be rotated.
 
+<p class='note warning'><strong>Warning:</strong> The rotation procedures described in this topic do not work if the certificates have already expired. If the certificates have expired, contact <%= vars.support_link %> for guidance.</p>
+
 To rotate certificates, follow one of these procedures:
 
 * To rotate non-rotatable certificates, contact <%= vars.support_link %>


### PR DESCRIPTION
Added another warning in the main "Rotate Certificates" section to contact support when certificates have already expired.