### PR TITLE
Update loggregator-network-paths.html.md.erb

### DIFF
--- a/networking/loggregator-network-paths.html.md.erb
+++ b/networking/loggregator-network-paths.html.md.erb
@@ -47,6 +47,7 @@ The following table lists network communication paths for Log Cache:
 | gorouter | log-cache (Auth Proxy) | 8083 | TCP | HTTP | OAuth |
 | log-cache (Auth Proxy) | uaa | 8443 | TCP | HTTPS | TLS |
 | log-cache (Auth Proxy) | cloud_controller | 9024 | TCP | HTTPS | TLS |
+| Any&#42; | doppler ( Log-Cache Syslog Server) | 6067 | TCP | TCP | TLS |
 
 <sup>&#42;</sup>Any source VM can send requests to the specified destination within its subnet.
 


### PR DESCRIPTION
Since TAS 2.8, log-cache can ingest from the log-cache-syslog-server if it is enabled. The log-cache-syslog-server is colocated on the Doppler VM and will listen on port 6067.