### PR TITLE
Update loggregator-network-paths.html.md.erb

### DIFF
--- a/networking/loggregator-network-paths.html.md.erb
+++ b/networking/loggregator-network-paths.html.md.erb
@@ -22,7 +22,7 @@ The following table lists network communication paths for Loggregator:
 | loggregator_trafficcontroller (Reverse Log Proxy) | doppler | 8082 | TCP | gRPC over HTTP/2 | Mutual TLS |
 | Any&#42; | loggregator_trafficcontroller (<%= vars.app_runtime_abbr %> authentication proxy) | 8083 | TCP | HTTP | OAuth |
 | loggregator_trafficcontroller (Route Registrar) | nats | 4222 | TCP | NATS | Basic authentication |
-| loggregator_trafficcontroller (Metrics Forwarder) | BOSH Director (Metrics Server) | 25595 and 8443 | TCP | gRPC over HTTP/2 | Mutual TLS |
+| loggregator_trafficcontroller (Metrics Forwarder) | BOSH Director (Metrics Server) | 25555 and 8443 | TCP | gRPC over HTTP/2 | Mutual TLS |
 | loggregator_trafficcontroller | doppler (Log Cache) | 8080 | TCP | gRPC over HTTP/2 | Mutual TLS |
 | loggregator_trafficcontroller (Reverse Log Proxy Gateway) | cloud_controller | 9023 | TCP | HTTPS | Mutual TLS |
 | Any&#42; | loggregator_trafficcontroller (Reverse Log Proxy Gateway) | 8088 | TCP | HTTP/Server Sent Events | OAuth |


### PR DESCRIPTION
bosh-system-metrics-forwarder (loggregator_trafficcontroller > bosh director) traffic on ports 25555 and 8443 need to be allowed.