### PR TITLE
Remove service mesh documentation

### DIFF
--- a/networking/routing-network-paths.html.md.erb
+++ b/networking/routing-network-paths.html.md.erb
@@ -51,27 +51,6 @@ The following table lists network communication paths for TCP routing:
 <sup>&#42;&#42;</sup> MySQL authentication uses the MySQL native password method.
 
 
-## <a id="service-mesh"></a> Service Mesh (Optional)
-
-The following table lists network communication paths for service mesh:
-
-| Source VM | Destination VM | Port | Transport Layer Protocol | App Layer Protocol | Security and Authentication |
-| --------- | -------------- | ---- | ------------------------ | ------------------ | ---------------------------- |
-| cloud_controller (cloud\_controller\_ng) | istio_control (Copilot) | 9001 | TCP | GRPC | Mutual TLS |
-| istio_control (Copilot) | diego_database (BBS) | 8889 | TCP | HTTP | Mutual TLS |
-| istio_control (Pilot-Discovery) | istio_control (Copilot) | 9009 | TCP | GRPC | Mutual TLS |
-| istio_router (Envoy) | App containers | Varies | TCP | HTTP/HTTPS | Optional TLS |
-| istio_router (Envoy) | istio_control (Pilot-Discovery) | 15010 | TCP | GRPC | None |
-| Load balancer | istio_router (Envoy) | 80 | TCP | HTTP | None |
-| Load balancer | istio_router (Envoy) | 443 | TCP | HTTPS | TLS |
-| Load balancer (health check) | istio_router (Envoy) | 8002 | TCP | HTTP | None |
-| route_syncer (CC Route Syncer) | istio_control (Copilot) | 9001 | TCP | GRPC | Mutual TLS |
-| route_syncer (CC Route Syncer) | mysql_proxy* | 3306 | TCP | MySQL | MySQL authentication* |
-| N/A (admin) | istio_router (Envoy) | 8001 | TCP | HTTP | None |
-| N/A (for Envoy secure GRPC communication) | istio_control (Pilot-Discovery) | 15012 | TCP | GRPC | Mutual TLS |
-| N/A (for HTTP discovery service) | istio_control (Pilot-Discovery) | 8080 | TCP | HTTP | None |
-| N/A (for Pilot's self-monitoring) | istio_control (Pilot-Discovery) | 9093 | TCP | HTTP | None |
-
 <sup>*</sup>Applies only to deployments where internal MySQL is selected as the database.
 
 <%= partial "bosh-dns" %>


### PR DESCRIPTION
This beta/experimental feature was never made generally available and
has since been officially deprecated per:
https://github.com/cloudfoundry-attic/istio-release/blob/develop/README.md#deprecated