### PR TITLE
Removes messaging-nats

### DIFF
--- a/networking/nats-network-paths.html.md.erb
+++ b/networking/nats-network-paths.html.md.erb
@@ -5,7 +5,7 @@ owner: NATS
 
 This topic describes NATS internal network communication paths with other <%= vars.app_runtime_full %> (<%= vars.app_runtime_abbr %>) components.
 
-For more information about NATS, see [Messaging (NATS)](https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/architecture/messaging-nats.html).
+For more information about how Cloud Foundry integrates NATS, see [TAS for VMs Routing Architecture](https://docs.pivotal.io/application-service/<%= product_info['local_product_version'].to_s.sub('.','-') %>/concepts/cf-routing-architecture.html).
 
 
 ## <a id="publish"></a> Publish Communications


### PR DESCRIPTION
We are removing the messaging-nats page and all hyperlinks to said paid
because:
- the document does not facilitate operator/app developer understanding
and is more suited for tile developers
- the document contents are a copy-paste from the NATS docs
- information about NATS is documented elsewhere

[#174578977](https://www.pivotaltracker.com/story/show/174578977)

✨  Can you please propagate this change for 2.7 -> master

Links to all related PRs: 
* https://github.com/cloudfoundry/docs-cloudfoundry-concepts/pull/145
* https://github.com/cloudfoundry/docs-book-cloudfoundry/pull/102
* https://github.com/pivotal-cf/docs-book-windows/pull/2
* https://github.com/pivotal-cf/docs-ops-manager/pull/92
* https://github.com/pivotal-cf/docs-partials/pull/25
* https://github.com/pivotal-cf/docs-pas/pull/2
* https://github.com/pivotal-cf/docs-pcf-security/pull/115


cc: @jrussett